### PR TITLE
add buffer flush

### DIFF
--- a/followedTask.go
+++ b/followedTask.go
@@ -454,6 +454,27 @@ func (ft *FollowedTask) processFrame(frame *nomadApi.StreamFrame, streamState St
 			}
 		}
 	}
+	if len(streamState.MultiLineBuf) != 0 {
+		ft.log.Tracef(
+			logContext,
+			"Flushing multiline:\n%s\n at the end of processFrame",
+			streamState.MultiLineBuf,
+		)
+		l := createJsonLog(ft.logTemplate, streamState.MultiLineBuf, streamState.LastTimestamp)
+		s, err := l.ToJSON()
+		if err != nil {
+			ft.log.DeadLetterf(
+				logContext,
+				l,
+				"Error building json log message: %v",
+				err,
+			)
+		} else {
+			jsons = append(jsons, s)
+		}
+		streamState.BufReset()
+	}
+
 	return jsons, streamState
 }
 


### PR DESCRIPTION
We've noticed that some logs are missing. Upon further inspection I realized that it is a bug when all logs arrive in a single frame(happens with all batchjobs), and no more logs arrive, buffer never ends up being flushed. The current logic only flushes on the new messages. This new logic has a risk of splitting mutliline logs into single line logs, but I think its better than missing logs for batch jobs